### PR TITLE
Fix issue with power calculation.

### DIFF
--- a/src/diyfp.rs
+++ b/src/diyfp.rs
@@ -217,8 +217,8 @@ inline DiyFp GetCachedPower(int e, int* K) {
 */
 #[inline]
 fn get_cached_power(e: $expty) -> (DiyFp, isize) {
-    let dk = (3 - $diy_significand_size - e) as f64 * 0.30102999566398114f64;
-    let mut k = dk as isize - $min_power - 1;
+    let dk = (3 - $diy_significand_size - e) as f64 * 0.30102999566398114f64 - ($min_power + 1) as f64;
+    let mut k = dk as isize;
     if dk - k as f64 > 0.0 {
         k += 1;
     }


### PR DESCRIPTION
The `get_cached_power` function doesn't quite match the reference implementation. The if check uses the variable `dk` which was calculated differently in the Rust implementation.

This causes issues with numbers within a certain range. (e.g.  `5.0e-13`).