### PR TITLE
Only include necessary files in package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "dtoa"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Fast functions for printing floating-point primitives to an io::Write"
 repository = "https://github.com/dtolnay/dtoa"
 documentation = "https://github.com/dtolnay/dtoa"
 categories = ["value-formatting"]
+
+include = ["LICENSE-*", "src/*.rs", "Cargo.toml", "README.md"]


### PR DESCRIPTION
Currently the package includes a png file... which is meaningless.

Use `include` instead so that we don't mess including everything we don't need.