### PR TITLE
Make grisu_round safe

### DIFF
--- a/src/dtoa.rs
+++ b/src/dtoa.rs
@@ -195,8 +195,11 @@ unsafe fn digit_gen(w: DiyFp, mp: DiyFp, mut delta: $sigty, buffer: *mut u8, mut
         p2 *= 10;
         delta *= 10;
         let d = (p2 >> -one.e) as u8;
+
+        let next_digit = &mut *buffer.offset(len);
+
         if d != 0 || len != 0 {
-            *buffer.offset(len) = b'0' + d;
+            *next_digit = b'0' + d;
             len += 1;
         }
         p2 &= one.f - 1;
@@ -204,8 +207,7 @@ unsafe fn digit_gen(w: DiyFp, mp: DiyFp, mut delta: $sigty, buffer: *mut u8, mut
         if p2 < delta {
             k += kappa as isize;
             let index = -(kappa as isize);
-            let dest_digit = &mut *buffer.offset(len - 1);
-            grisu_round(dest_digit, delta, p2, one.f, wp_w.f * if index < 9 { POW10[-(kappa as isize) as usize] } else { 0 });
+            grisu_round(next_digit, delta, p2, one.f, wp_w.f * if index < 9 { POW10[-(kappa as isize) as usize] } else { 0 });
             return (len, k);
         }
     }

--- a/src/dtoa.rs
+++ b/src/dtoa.rs
@@ -157,16 +157,18 @@ unsafe fn digit_gen(w: DiyFp, mp: DiyFp, mut delta: $sigty, buffer: *mut u8, mut
             1 => { d = p1;              p1 =           0; }
             _ => {}
         }
+
+        let next_digit = &mut *buffer.offset(len);
+
         if d != 0 || len != 0 {
-            *buffer.offset(len) = b'0' + d as u8;
+            *next_digit = b'0' + d as u8;
             len += 1;
         }
         kappa -= 1;
         let tmp = (p1 as $sigty << -one.e) + p2;
         if tmp <= delta {
             k += kappa as isize;
-            let dest_digit = &mut *buffer.offset(len - 1);
-            grisu_round(dest_digit, delta, tmp, POW10[kappa] << -one.e, wp_w.f);
+            grisu_round(next_digit, delta, tmp, POW10[kappa] << -one.e, wp_w.f);
             return (len, k);
         }
     }

--- a/src/dtoa.rs
+++ b/src/dtoa.rs
@@ -54,11 +54,11 @@ inline void GrisuRound(char* buffer, int len, uint64_t delta, uint64_t rest, uin
 */
 
 #[inline]
-unsafe fn grisu_round(buffer: *mut u8, len: isize, delta: $sigty, mut rest: $sigty, ten_kappa: $sigty, wp_w: $sigty) {
+fn grisu_round(dest_digit: &mut u8, delta: $sigty, mut rest: $sigty, ten_kappa: $sigty, wp_w: $sigty) {
     while rest < wp_w && delta - rest >= ten_kappa &&
            (rest + ten_kappa < wp_w || // closer
             wp_w - rest > rest + ten_kappa - wp_w) {
-        *buffer.offset(len - 1) -= 1;
+        *dest_digit -= 1;
         rest += ten_kappa;
     }
 }
@@ -165,7 +165,8 @@ unsafe fn digit_gen(w: DiyFp, mp: DiyFp, mut delta: $sigty, buffer: *mut u8, mut
         let tmp = (p1 as $sigty << -one.e) + p2;
         if tmp <= delta {
             k += kappa as isize;
-            grisu_round(buffer, len, delta, tmp, POW10[kappa] << -one.e, wp_w.f);
+            let dest_digit = &mut *buffer.offset(len - 1);
+            grisu_round(dest_digit, delta, tmp, POW10[kappa] << -one.e, wp_w.f);
             return (len, k);
         }
     }
@@ -201,7 +202,8 @@ unsafe fn digit_gen(w: DiyFp, mp: DiyFp, mut delta: $sigty, buffer: *mut u8, mut
         if p2 < delta {
             k += kappa as isize;
             let index = -(kappa as isize);
-            grisu_round(buffer, len, delta, p2, one.f, wp_w.f * if index < 9 { POW10[-(kappa as isize) as usize] } else { 0 });
+            let dest_digit = &mut *buffer.offset(len - 1);
+            grisu_round(dest_digit, delta, p2, one.f, wp_w.f * if index < 9 { POW10[-(kappa as isize) as usize] } else { 0 });
             return (len, k);
         }
     }

--- a/src/dtoa.rs
+++ b/src/dtoa.rs
@@ -54,13 +54,15 @@ inline void GrisuRound(char* buffer, int len, uint64_t delta, uint64_t rest, uin
 */
 
 #[inline]
-fn grisu_round(dest_digit: &mut u8, delta: $sigty, mut rest: $sigty, ten_kappa: $sigty, wp_w: $sigty) {
+fn grisu_round(mut last_digit: u8, delta: $sigty, mut rest: $sigty, ten_kappa: $sigty, wp_w: $sigty) -> u8 {
     while rest < wp_w && delta - rest >= ten_kappa &&
            (rest + ten_kappa < wp_w || // closer
             wp_w - rest > rest + ten_kappa - wp_w) {
-        *dest_digit -= 1;
+        last_digit -= 1;
         rest += ten_kappa;
     }
+
+    last_digit
 }
 
 /*
@@ -168,7 +170,7 @@ unsafe fn digit_gen(w: DiyFp, mp: DiyFp, mut delta: $sigty, buffer: *mut u8, mut
         let tmp = (p1 as $sigty << -one.e) + p2;
         if tmp <= delta {
             k += kappa as isize;
-            grisu_round(next_digit, delta, tmp, POW10[kappa] << -one.e, wp_w.f);
+            *next_digit = grisu_round(*next_digit, delta, tmp, POW10[kappa] << -one.e, wp_w.f);
             return (len, k);
         }
     }
@@ -207,7 +209,7 @@ unsafe fn digit_gen(w: DiyFp, mp: DiyFp, mut delta: $sigty, buffer: *mut u8, mut
         if p2 < delta {
             k += kappa as isize;
             let index = -(kappa as isize);
-            grisu_round(next_digit, delta, p2, one.f, wp_w.f * if index < 9 { POW10[-(kappa as isize) as usize] } else { 0 });
+            *next_digit = grisu_round(*next_digit, delta, p2, one.f, wp_w.f * if index < 9 { POW10[-(kappa as isize) as usize] } else { 0 });
             return (len, k);
         }
     }


### PR DESCRIPTION
This is a tentative PR; I don't know if you want to go in this direction.

I was wondering what it would take to start making the code safe, have less pointer arithmetic, etc.  I got as far as making `grisu_round` safe, which is not much, but it seems to shave a few ns off the benchmarks.
