### PR TITLE
Adopt 2018-edition-friendly syntax for trait method arg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub fn write<W: io::Write, V: Floating>(wr: W, value: V) -> io::Result<usize> {
 
 /// An floating point number that can be formatted by `dtoa::write`.
 pub trait Floating {
-    fn write<W: io::Write>(self, W) -> io::Result<usize>;
+    fn write<W: io::Write>(self, wr: W) -> io::Result<usize>;
 }
 
 impl Floating for f32 {


### PR DESCRIPTION
This allows the code to be parsed by a 2018-only parser.