### PR TITLE
Resolve unnecessary_transmutes warning in nightly-2025-04-25

### DIFF
--- a/src/diyfp.rs
+++ b/src/diyfp.rs
@@ -138,7 +138,7 @@ macro_rules! diyfp {
             */
             #[cfg_attr(feature = "no-panic", no_panic)]
             unsafe fn from(d: $fty) -> Self {
-                let u: $mask_type = mem::transmute(d);
+                let u: $mask_type = <$fty>::to_bits(d);
 
                 let biased_e = ((u & $exponent_mask) >> $significand_size) as $expty;
                 let significand = u & $significand_mask;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ mod diyfp;
 #[macro_use]
 mod dtoa;
 
-use core::mem::{self, MaybeUninit};
+use core::mem::MaybeUninit;
 use core::slice;
 use core::str;
 #[cfg(feature = "no-panic")]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/136083

```console
warning: unnecessary transmute
   --> src/diyfp.rs:141:37
    |
141 |                   let u: $mask_type = mem::transmute(d);
    |                                       ^^^^^^^^^^^^^^^^^ help: replace this with: `f32::to_bits(d)`
    |
   ::: src/lib.rs:197:9
    |
197 | /         dtoa! {
198 | |             floating_type: f32,
199 | |             significand_type: u32,
200 | |             exponent_type: i32,
...   |
211 | |             min_power: (-36),
212 | |         };
    | |_________- in this macro invocation
    |
    = note: `#[warn(unnecessary_transmutes)]` on by default
    = note: this warning originates in the macro `diyfp` which comes from the expansion of the macro `dtoa` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unnecessary transmute
   --> src/diyfp.rs:141:37
    |
141 |                   let u: $mask_type = mem::transmute(d);
    |                                       ^^^^^^^^^^^^^^^^^ help: replace this with: `f64::to_bits(d)`
    |
   ::: src/lib.rs:243:9
    |
243 | /         dtoa! {
244 | |             floating_type: f64,
245 | |             significand_type: u64,
246 | |             exponent_type: isize,
...   |
257 | |             min_power: (-348),
258 | |         };
    | |_________- in this macro invocation
    |
    = note: this warning originates in the macro `diyfp` which comes from the expansion of the macro `dtoa` (in Nightly builds, run with -Z macro-backtrace for more info)
```